### PR TITLE
Allow user to choose alpha domain from pre-defined supported list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Schechter galaxy luminosity distribution for NumPyro**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/alserene/numpyro_schechter/main/docs/assets/logo.png" alt="numpyro_schechter logo" width="300"/>
+  <img src="https://raw.githubusercontent.com/alserene/numpyro_schechter/main/docs/assets/logo.png" alt="Schechter distribution logo for numpyro_schechter" width="300"/>
 </p>
 
 <p align="center">
@@ -28,31 +28,47 @@
 
 ## Overview
 
-`numpyro_schechter` provides a NumPyro-compatible probability distribution for Bayesian inference with Schechter luminosity functions in absolute magnitude space. Built for astronomers and statisticians, it includes a JAX-compatible custom implementation of the upper incomplete gamma function, enabling stable and differentiable modelling within probabilistic programming frameworks.
+`numpyro_schechter` provides a NumPyro-compatible probability distribution for Bayesian inference with Schechter luminosity functions in absolute magnitude space.
 
-**Note:** Due to the custom implementation of the incomplete gamma function, the distribution is **only valid when `alpha + 1` is in the range (-3, 3) and is non-integer**. Users are responsible for ensuring parameters fall within this valid range.
+Built for astronomers and statisticians, it includes a JAX-compatible, differentiable implementation of the upper incomplete gamma function, enabling stable and efficient modelling in probabilistic programming frameworks.
+
+---
+
+## Parameter Constraints
+
+Due to the custom normalisation logic, some constraints apply:
+
+- `alpha` must be real and non-integer.
+- The valid range of `alpha + 1` depends on `alpha_domain_depth`. By default, `alpha_domain_depth=3`, which supports the domain `-3 < alpha + 1 < 3`.
+- To model more extreme values of `alpha`, increase the `alpha_domain_depth` parameter (see below).
+- The list of valid depths is fixed and can be queried programmatically:
+  ```python
+  from numpyro_schechter import SchechterMag
+  SchechterMag.supported_depths()
+  # -> [3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30]
+  ```
 
 ---
 
 ## Installation
 
-You can install the latest development version directly from GitHub:
-
-```bash
-pip install git+https://github.com/alserene/numpyro_schechter.git
-```
-
-Or from PyPI:
+From PyPI:
 
 ```bash
 pip install numpyro_schechter
+```
+
+From GitHub (latest development version):
+
+```bash
+pip install git+https://github.com/alserene/numpyro_schechter.git
 ```
 
 ---
 
 ## Usage
 
-Here is a minimal example showing how to instantiate and use the `SchechterMag` distribution:
+Here is a minimal example showing how to use the `SchechterMag` distribution:
 
 ```python
 import jax.numpy as jnp
@@ -79,7 +95,7 @@ def model(mag_obs):
 # You can now run inference with NumPyro's MCMC
 # e.g., numpyro.infer.MCMC(...).run(rng_key, model, mag_obs=...)
 
-# Note: Sampling is not implemented.
+# Note: Sampling is not implemented for SchechterMag; it is intended for use as a likelihood in inference.
 ```
 
 For detailed usage and API documentation, please visit the [Documentation](https://numpyro-schechter.readthedocs.io/).
@@ -101,7 +117,7 @@ poetry run pytest
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file.
 
 ---
 

--- a/src/numpyro_schechter/distribution.py
+++ b/src/numpyro_schechter/distribution.py
@@ -1,34 +1,72 @@
 import jax.numpy as jnp
 from numpyro.distributions import Distribution, constraints
-from .math_utils import custom_gammaincc, schechter_mag
+from .math_utils import custom_gammaincc, schechter_mag, SUPPORTED_ALPHA_DOMAIN_DEPTHS
 
 
 class SchechterMag(Distribution):
     """
-    NumPyro-compatible distribution based on the Schechter luminosity function in magnitude space.
+    NumPyro-compatible distribution based on the Schechter luminosity function in absolute magnitude space.
+
+    This distribution models galaxy number densities using the Schechter parameterisation in magnitude space:
+        φ(M) ∝ 10**[0.4(α + 1)(M* − M)] * exp[−10**(0.4(M* − M))]
+
+    Normalisation is handled via a custom, recurrence-based computation of the upper incomplete gamma function,
+    allowing support for automatic differentiation in JAX/NumPyro.
+
+    Constraints:
+    - `alpha` must be real and non-integer.
+    - By default, the valid domain for `alpha + 1` is (−3, 3), corresponding to `alpha_domain_depth=3`. To support broader domains, increase `alpha_domain_depth` (see note).
+    - `mag_obs` must contain values such that `10**(0.4(M_star − M)) > 0`.
+
+    Note:
+    To ensure compatibility with NUTS/HMC (which uses JAX's reverse-mode autodiff), only a fixed set of
+    `alpha_domain_depth` values are supported.
+    See `SchechterMag.supported_depths()` for available options (e.g., 3, 5, 10, 15).
     """
+
     support = constraints.real
 
     @property
     def has_rsample(self) -> bool:
         return False
+    
+    @staticmethod
+    def supported_depths():
+        """
+        Returns a list of supported values for `alpha_domain_depth`, corresponding to increasing valid alpha ranges.
+        Larger `alpha_domain_depth` will see reduced performance due to the corresponding increase in recursions.
+        """
+        return SUPPORTED_ALPHA_DOMAIN_DEPTHS
 
-    def __init__(self, alpha, M_star, logphi, mag_obs, validate_args=None):
+    def __init__(self, alpha, M_star, logphi, mag_obs, alpha_domain_depth=3, validate_args=None):
         self.alpha = alpha
         self.M_star = M_star
         self.logphi = logphi
         self.phi_star = jnp.exp(logphi)
         self.mag_obs = mag_obs
+        self.alpha_domain_depth = alpha_domain_depth
 
         # Normalisation over observed magnitude range
         M_min, M_max = jnp.min(mag_obs), jnp.max(mag_obs)
         a = alpha + 1.0
         x_min = 10 ** (0.4 * (M_star - M_max))
         x_max = 10 ** (0.4 * (M_star - M_min))
-        norm = self.phi_star * (custom_gammaincc(a, x_min) - custom_gammaincc(a, x_max))
+        norm = self.phi_star * (custom_gammaincc(a, x_min, recur_depth=self.alpha_domain_depth) - custom_gammaincc(a, x_max, recur_depth=self.alpha_domain_depth))
         self.norm = jnp.where(norm > 0, norm, jnp.inf)
 
         super().__init__(batch_shape=(), event_shape=(), validate_args=validate_args)
+
+    def __str__(self):
+        return (
+            f"SchechterMag distribution\n"
+            f"  alpha = {self.alpha}\n"
+            f"  M_star = {self.M_star}\n"
+            f"  logphi = {self.logphi}\n"
+            f"  alpha_domain_depth = {self.alpha_domain_depth}"
+        )
+
+    def __repr__(self):
+        return str(self)
 
     def log_prob(self, value):
         pdf = schechter_mag(self.phi_star, self.M_star, self.alpha, value) / self.norm

--- a/src/numpyro_schechter/math_utils.py
+++ b/src/numpyro_schechter/math_utils.py
@@ -7,6 +7,8 @@ from jax._src.typing import Array, ArrayLike
 
 jax.config.update("jax_enable_x64", True)
 
+SUPPORTED_ALPHA_DOMAIN_DEPTHS = [3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30]
+
 
 def schechter_mag(phi_star, M_star, alpha, M):
     """
@@ -22,6 +24,23 @@ def schechter_mag(phi_star, M_star, alpha, M):
     )
 
 
+def custom_gammaincc(s: ArrayLike, x: ArrayLike, recur_depth: int = 3) -> Array:
+    """
+    Computes Γ(s, x) using a recurrence-based method.
+
+    Valid for real, non-integer s. The default supported domain for s is approximately (-3, 3), corresponding to `recur_depth=3`.
+    Increase `recur_depth` to extend this range. Input `x` must be positive.
+
+    Raises:
+        ValueError: If `recur_depth` is not in the supported set.
+    """
+    s, x = promote_args_inexact("custom_gammaincc", s, x)
+    if recur_depth not in _dispatch_table:
+        raise ValueError(f"Unsupported recur_depth={recur_depth}. "
+                         f"Must be one of {SUPPORTED_ALPHA_DOMAIN_DEPTHS}.")
+    return _dispatch_table[recur_depth](s, x)
+
+
 def s_positive(s: ArrayLike, x: ArrayLike) -> Array:
     """
     Regularised upper incomplete gamma function * Gamma(s)
@@ -29,35 +48,36 @@ def s_positive(s: ArrayLike, x: ArrayLike) -> Array:
     return gamma(s) * gammaincc(s, x)
 
 
-def compute_gamma(s: ArrayLike, x: ArrayLike) -> Array:
+def compute_gamma(s: ArrayLike, x: ArrayLike, recur_depth: int) -> Array:
     def recur(gamma_val, s, x):
         return (gamma_val - x ** s * jnp.exp(-x)) / s
 
     def compute_recurrence(carry, _):
         gamma_val, s = carry
-        new_gamma = lax.cond(
+        new_s = s - 1
+        gamma_val_new = lax.cond(
             jnp.isinf(gamma_val),
             lambda _: jnp.inf,
-            lambda _: recur(gamma_val, s - 1, x),
+            lambda _: recur(gamma_val, new_s, x),
             operand=None
         )
-        return (new_gamma, s - 1), new_gamma
+        return (gamma_val_new, new_s), gamma_val_new
 
-    recur_depth = 3
-    s_start = s + 3
+    s_start = s + recur_depth
     gamma_start = s_positive(s_start, x)
 
     initial_carry = (gamma_start, s_start)
     result, _ = lax.scan(compute_recurrence, initial_carry, None, length=recur_depth)
-
     return result[0]
 
 
-@jit
-def custom_gammaincc(s: ArrayLike, x: ArrayLike) -> Array:
-    """
-    Computes Γ(s, x) using a recurrence-based method.
-    Valid for real s (non-integers in -3 < s < 3) and x > 0.
-    """
-    s, x = promote_args_inexact("custom_gammaincc", s, x)
-    return compute_gamma(s, x)
+_dispatch_table = {}
+
+for depth in SUPPORTED_ALPHA_DOMAIN_DEPTHS:
+    def _make_fn(recur_depth=depth):
+        @jit
+        def fn(s, x):
+            return compute_gamma(s, x, recur_depth)
+        return fn
+
+    _dispatch_table[depth] = _make_fn()

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,10 +1,12 @@
 import jax.numpy as jnp
 import numpyro
+import pytest
 import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS
 from jax import random
 
 from numpyro_schechter.distribution import SchechterMag
+from numpyro_schechter.math_utils import SUPPORTED_ALPHA_DOMAIN_DEPTHS
 
 
 def test_schechtermag_inference_runs():
@@ -21,3 +23,28 @@ def test_schechtermag_inference_runs():
     mcmc.run(rng_key, mag_obs=mag_data)
     samples = mcmc.get_samples()
     assert "alpha" in samples and "M_star" in samples and "logphi" in samples
+
+
+def test_schechter_log_prob_finite():
+    mag_obs = jnp.linspace(-23, -20, 5)
+    d = SchechterMag(alpha=-1.2, M_star=-21.0, logphi=-2.5, mag_obs=mag_obs)
+    logp = d.log_prob(mag_obs)
+    assert jnp.all(jnp.isfinite(logp))
+
+
+@pytest.mark.parametrize("depth", SUPPORTED_ALPHA_DOMAIN_DEPTHS)
+def test_log_prob_finite_for_supported_depth(depth):
+    mag_data = jnp.linspace(-22.5, -20.5, 10)
+    dist = SchechterMag(alpha=-1.0, M_star=-21.0, logphi=-3.0, mag_obs=mag_data, alpha_domain_depth=depth)
+    logp = dist.log_prob(mag_data)
+    assert jnp.all(jnp.isfinite(logp)), f"logp failed for depth {depth}"
+
+
+def test_invalid_alpha_domain_depth():
+    mag_data = jnp.linspace(-22.5, -20.5, 10)
+    with pytest.raises(ValueError, match="Unsupported recur_depth"):
+        SchechterMag(alpha=-1.0, M_star=-21.0, logphi=-3.0, mag_obs=mag_data, alpha_domain_depth=12)
+
+
+def test_supported_depths_list():
+    assert SchechterMag.supported_depths() == SUPPORTED_ALPHA_DOMAIN_DEPTHS

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -3,7 +3,7 @@ import jax
 import jax.numpy as jnp
 from sympy import uppergamma
 
-from numpyro_schechter.math_utils import custom_gammaincc
+from numpyro_schechter.math_utils import custom_gammaincc, SUPPORTED_ALPHA_DOMAIN_DEPTHS
 
 
 @pytest.mark.parametrize("x", [0.1, 0.5, 1.0, 5.0, 10.0, 30.0])
@@ -13,6 +13,23 @@ def test_custom_gammaincc_against_sympy(s, x):
     sympy_result = uppergamma(s, x).evalf()
 
     assert jax_result == pytest.approx(float(sympy_result), rel=1e-3)
+
+
+@pytest.mark.parametrize("s", [-0.001, 0.999])
+def test_non_integer_s_near_integer(s):
+    val = custom_gammaincc(s, 1.0)
+    assert jnp.isfinite(val)
+
+
+@pytest.mark.parametrize("depth", SUPPORTED_ALPHA_DOMAIN_DEPTHS)
+def test_custom_gammaincc_supported_depths(depth):
+    val = custom_gammaincc(1.5, 2.0, recur_depth=depth)
+    assert jnp.isfinite(val)
+
+
+def test_invalid_depth_raises():
+    with pytest.raises(ValueError, match="Unsupported recur_depth"):
+        custom_gammaincc(1.5, 1.0, recur_depth=12)
 
 
 def test_grad():


### PR DESCRIPTION
While the main astronomy use-case fits within the default supported range of `-3 < alpha + 1 < 3`, there may occur cases where a user might want a broader domain. To maintain auto-differentiability, a pre-defined set of available domains has been constructed for the user to choose from. The wider the domain, the greater the impact to performance due to the increased recursion.